### PR TITLE
Update nx_stm32_eth_driver.c

### DIFF
--- a/Middlewares/ST/netxduo/common/drivers/ethernet/nx_stm32_eth_driver.c
+++ b/Middlewares/ST/netxduo/common/drivers/ethernet/nx_stm32_eth_driver.c
@@ -1754,7 +1754,7 @@ static UINT  _nx_driver_hardware_initialize(NX_IP_DRIVER *driver_req_ptr)
   FilterConfig.HashMulticast = DISABLE;
   FilterConfig.DestAddrInverseFiltering = DISABLE;
   FilterConfig.PassAllMulticast = DISABLE;
-  FilterConfig.BroadcastFilter = ENABLE;
+  FilterConfig.BroadcastFilter = DISABLE;
   FilterConfig.SrcAddrInverseFiltering = DISABLE;
   FilterConfig.SrcAddrFiltering = DISABLE;
   FilterConfig.HachOrPerfectFilter = DISABLE;


### PR DESCRIPTION
fix:
Unable to receive MAC broadcast messages after joining or leaving multicast, resulting in inability to respond with ARP

## IMPORTANT INFORMATION

Pull-requests are **not** accepted on this repository. Please use issues to report any bug or request.
